### PR TITLE
Detect system architecture with 'uname -m' to install correct binary

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,7 +21,13 @@ install() {
   local -r install_version="$2"
   local -r install_path="$3"
   local -r install_path_bin="${install_path}/bin"
-  local -r platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+  arch=$(uname -m)
+  case $arch in
+    arm64) arch="arm64";; # m1 macs
+    aarch64) arch="arm64";;
+    *) arch="amd64";;
+  esac
+  local -r platform="$(uname | tr '[:upper:]' '[:lower:]')-${arch}"
   local -r download_url="${DOWNLOAD_BASE_URL}/v${install_version}/${BINARY_NAME}-${platform}"
   local -r download_path="${TMP_DOWNLOAD_DIR}/${BINARY_NAME}"
 


### PR DESCRIPTION
Argocd releases binaries for a few different system architectures and this plugin currently hardcodes the download url to amd64. This change will use `uname -m` to detect the system architecture to download/install the correct binary for the host installing argocd

```
user@raspberrypi:~$ asdf plugin add argocd https://github.com/mathew-fleisch/asdf-argocd.git
user@raspberrypi:~$ asdf install argocd latest
Downloading from https://github.com/argoproj/argo-cd/releases/download/v2.3.2/argocd-linux-arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   657  100   657    0     0   2433      0 --:--:-- --:--:-- --:--:--  2424
100  112M  100  112M    0     0  15.0M      0  0:00:07  0:00:07 --:--:-- 15.9M
Installing binary
user@raspberrypi:~$ argocd version
  argocd: v2.3.2+ecc2af9
  BuildDate: 2022-03-23T02:06:48Z
  GitCommit: ecc2af9dcaa12975e654cde8cbbeaffbb315f75c
  GitTreeState: clean
  GoVersion: go1.17.6
  Compiler: gc
  Platform: linux/arm64```